### PR TITLE
Lazy load for Image in intro

### DIFF
--- a/sections/Intro.jsx
+++ b/sections/Intro.jsx
@@ -29,6 +29,7 @@ const Intro = () => {
                 height={300}
                 src="/images/cartoon 0.png"
                 width={300}
+                placeholder="blur"
               />
               <Resume />
             </div>


### PR DESCRIPTION
This option shows the image blurred until it renders completely and stays blurred until the image is ready to be display

Using this placeholder attr improves UI as it doesn't show the empty space until the image is loaded in devices with slow internet.